### PR TITLE
chore: remove the filebrowser pak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ DEVELOPER_VERSION := 0.5.0
 DREAMCAST_EMULATOR_VERSION := 0.3.4
 DROPBEAR_SSH_VERSION := 0.5.0
 DUFS_SERVER_VERSION := 0.5.5
-FILEBROWSER_VERSION := 0.5.2
 FN_EDITOR_VERSION := 0.3.4
 MOONLIGHT_VERSION := 0.3.3
 N64_EMULATOR_VERSION := 0.2.1
@@ -40,7 +39,6 @@ tools:
 	$(MAKE) developer
 	$(MAKE) dropbear-ssh
 	$(MAKE) dufs-server
-	$(MAKE) filebrowser
 	$(MAKE) fn-editor
 	$(MAKE) moonlight
 	$(MAKE) random-game
@@ -62,9 +60,6 @@ dropbear-ssh:
 
 dufs-server:
 	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-dufs-server-pak/releases/download/$(DUFS_SERVER_VERSION)/HTTP.Server.pak.zip" PAK_NAME="HTTP Server"
-	
-filebrowser:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-filebrowser-pak/releases/download/$(FILEBROWSER_VERSION)/HTTP.Filebrowser.pak.zip" PAK_NAME="HTTP Filebrowser"
 
 fn-editor:
 	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/trimui-brick-fn-editor-pak/releases/download/$(FN_EDITOR_VERSION)/FN.Editor.pak.zip" PAK_NAME="FN Editor"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Below are the paks sourced by this pak collection. Please refer to the licenses 
 - [Developer](https://github.com/josegonzalez/minui-developer-pak) by @josegonzalez
 - [Dropbear SSH Server](https://github.com/josegonzalez/minui-dropbear-server-pak) by @josegonzalez
 - [Dufs HTTP Server](https://github.com/josegonzalez/minui-dufs-server-pak) by @josegonzalez
-- [Filebrowser](https://github.com/josegonzalez/minui-filebrowser-pak) by @josegonzalez
 - [Fn Editor](https://github.com/josegonzalez/trimui-brick-fn-editor-pak) by @josegonzalez
 - [Moonlight](https://github.com/josegonzalez/trimui-brick-moonlight-pak) by @josegonzalez
 - [Random Game](https://github.com/josegonzalez/minui-random-game-pak) by @josegonzalez


### PR DESCRIPTION
This is already implemented by the Dufs HTTP Server pak, so there isn't any need to run both.

Closes #1