### PR TITLE
refactor: specify all paks in a json file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,3 @@
-COLLECTION_MANAGER_VERSION := 0.1.1
-DEVELOPER_VERSION := 0.5.0
-DREAMCAST_EMULATOR_VERSION := 0.3.4
-DROPBEAR_SSH_VERSION := 0.5.0
-DUFS_SERVER_VERSION := 0.5.5
-FN_EDITOR_VERSION := 0.3.4
-MOONLIGHT_VERSION := 0.3.3
-N64_EMULATOR_VERSION := 0.2.1
-RANDOM_GAME_VERSION := 0.3.1
-REMOTE_TERMINAL_VERSION := 0.5.2
-REPORT_VERSION := 0.6.1
-SCREENSHOT_MONITOR_VERSION := 0.5.0
-SFTPGO_VERSION := 0.3.1
-SYNCTHING_VERSION := 0.3.0
-TERMINAL_VERSION := 0.6.2
-USB_MASS_STORAGE_VERSION := 0.3.1
-WIFI_VERSION := 0.10.1
-
-
 FOLDER_NAME ?= "Pakman"
 ZIP_NAME ?= "Pakman.zip"
 
@@ -25,78 +6,26 @@ build: emus tools
 	zip -r $(ZIP_NAME) $(FOLDER_NAME)
 
 emus:
-	$(MAKE) dreamcast-emulator
-	$(MAKE) n64-emulator
-
-dreamcast-emulator:
-	$(MAKE) install-pak PAK_TYPE="Emus" PAK_URL="https://github.com/josegonzalez/minui-dreamcast-pak/releases/download/$(DREAMCAST_EMULATOR_VERSION)/DC.pak.zip" PAK_NAME="DC"
-	mkdir -p "$(FOLDER_NAME)/Roms/Sega Dreamcast (DC)"
-	touch "$(FOLDER_NAME)/Roms/Sega Dreamcast (DC)/.keep"
-
-n64-emulator:
-	$(MAKE) install-pak PAK_TYPE="Emus" PAK_URL="https://github.com/josegonzalez/minui-n64-pak/releases/download/$(N64_EMULATOR_VERSION)/N64.pak.zip" PAK_NAME="N64"
-	mkdir -p "$(FOLDER_NAME)/Roms/Nintendo 64 (N64)"
-	touch "$(FOLDER_NAME)/Roms/Nintendo 64 (N64)/.keep"
+	@jq -c '.emu_paks[]' paks.json | while read -r pak; do \
+		name=$$(echo $$pak | jq -r '.name'); \
+		repository=$$(echo $$pak | jq -r '.repository'); \
+		version=$$(echo $$pak | jq -r '.version'); \
+		pak_name=$$(echo $$pak | jq -r '.pak_name'); \
+		rom_folder=$$(echo $$pak | jq -r '.rom_folder'); \
+		$(MAKE) install-pak PAK_TYPE="Emus" PAK_URL="$$repository/releases/download/$$version/$$pak_name.pak.zip" PAK_NAME="$$pak_name"; \
+		mkdir -p "$(FOLDER_NAME)/$$rom_folder"; \
+		touch "$(FOLDER_NAME)/$$rom_folder/.keep"; \
+	done
 
 tools:
-	$(MAKE) collection-manager
-	$(MAKE) developer
-	$(MAKE) dropbear-ssh
-	$(MAKE) dufs-server
-	$(MAKE) fn-editor
-	$(MAKE) moonlight
-	$(MAKE) random-game
-	$(MAKE) report
-	$(MAKE) screenshot-monitor
-	$(MAKE) sftpgo
-	$(MAKE) syncthing
-	$(MAKE) wifi
-	$(MAKE) usb-mass-storage
-
-collection-manager:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/jiserra/Collection-Manager.pak/releases/download/$(COLLECTION_MANAGER_VERSION)/Collection.Manager.pak.zip" PAK_NAME="Collection Manager"
-
-developer:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-developer-pak/releases/download/$(DEVELOPER_VERSION)/Developer.pak.zip" PAK_NAME="Developer"
-
-dropbear-ssh:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-dropbear-server-pak/releases/download/$(DROPBEAR_SSH_VERSION)/SSH.Server.pak.zip" PAK_NAME="SSH Server"
-
-dufs-server:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-dufs-server-pak/releases/download/$(DUFS_SERVER_VERSION)/HTTP.Server.pak.zip" PAK_NAME="HTTP Server"
-
-fn-editor:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/trimui-brick-fn-editor-pak/releases/download/$(FN_EDITOR_VERSION)/FN.Editor.pak.zip" PAK_NAME="FN Editor"
-
-moonlight:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/trimui-brick-moonlight-pak/releases/download/$(MOONLIGHT_VERSION)/Moonlight.pak.zip" PAK_NAME="Moonlight"
-
-random-game:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-random-game-pak/releases/download/$(RANDOM_GAME_VERSION)/Random.Game.pak.zip" PAK_NAME="Random Game"
-
-remote-terminal:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-remote-terminal-pak/releases/download/$(REMOTE_TERMINAL_VERSION)/Remote.Terminal.pak.zip" PAK_NAME="Remote Terminal"
-
-report:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-report-pak/releases/download/$(REPORT_VERSION)/Report.pak.zip" PAK_NAME="Report"
-
-screenshot-monitor:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-screenshot-monitor-pak/releases/download/$(SCREENSHOT_MONITOR_VERSION)/Screenshot.Monitor.pak.zip" PAK_NAME="Screenshot Monitor"
-
-sftpgo:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-sftpgo-server-pak/releases/download/$(SFTPGO_VERSION)/FTP.Server.pak.zip" PAK_NAME="FTP Server"
-
-syncthing:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-syncthing-pak/releases/download/$(SYNCTHING_VERSION)/Syncthing.pak.zip" PAK_NAME="Syncthing"
-
-terminal:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-terminal-pak/releases/download/$(TERMINAL_VERSION)/Terminal.pak.zip" PAK_NAME="Terminal"
-
-wifi:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/minui-wifi-pak/releases/download/$(WIFI_VERSION)/Wifi.pak.zip" PAK_NAME="Wifi"
-
-usb-mass-storage:
-	$(MAKE) install-pak PAK_TYPE="Tools" PAK_URL="https://github.com/josegonzalez/trimui-brick-usb-mass-storage-pak/releases/download/$(USB_MASS_STORAGE_VERSION)/USB.Mass.Storage.pak.zip" PAK_NAME="USB Mass Storage"
+	@jq -c '.tool_paks[]' paks.json | while read -r pak; do \
+		name=$$(echo $$pak | jq -r '.name'); \
+		repository=$$(echo $$pak | jq -r '.repository'); \
+		version=$$(echo $$pak | jq -r '.version'); \
+		pak_name=$$(echo $$pak | jq -r '.pak_name'); \
+		pak_zip_file=$$(echo $$pak | jq -r '.pak_name' | tr " " .); \
+		$(MAKE) install-pak PAK_NAME="$$pak_name" PAK_TYPE="Tools" PAK_URL="$$repository/releases/download/$$version/$$pak_zip_file.pak.zip"; \
+	done
 
 install-pak:
 ifndef PAK_NAME

--- a/README.md
+++ b/README.md
@@ -24,12 +24,16 @@ Below are the paks sourced by this pak collection. Please refer to the licenses 
 
 ### Emu Paks
 
-#### `tg5040`
+<!-- begin emu paks -->
 
 - [Dreamcast](https://github.com/josegonzalez/minui-dreamcast-pak) by @josegonzalez
 - [N64](https://github.com/josegonzalez/minui-n64-pak) by @josegonzalez
 
+<!-- end emu paks -->
+
 ### Tool Paks
+
+<!-- begin tool paks -->
 
 - [Collection Manager](https://github.com/jiserra/Collection-Manager.pak) by @jiserra
 - [Developer](https://github.com/josegonzalez/minui-developer-pak) by @josegonzalez
@@ -46,3 +50,5 @@ Below are the paks sourced by this pak collection. Please refer to the licenses 
 - [Terminal](https://github.com/josegonzalez/minui-terminal-pak) by @josegonzalez
 - [Usb Mass Storage](https://github.com/josegonzalez/trimui-brick-usb-mass-storage-pak) by @josegonzalez
 - [Wifi](https://github.com/josegonzalez/minui-wifi-pak) by @josegonzalez
+
+<!-- end tool paks -->

--- a/paks.json
+++ b/paks.json
@@ -1,0 +1,110 @@
+{
+  "emu_paks": [
+    {
+      "name": "Dreamcast",
+      "repository": "https://github.com/josegonzalez/minui-dreamcast-pak",
+      "version": "0.3.4",
+      "pak_name": "DC",
+      "rom_folder": "Roms/Sega Dreamcast (DC)"
+    },
+    {
+      "name": "N64",
+      "repository": "https://github.com/josegonzalez/minui-n64-pak",
+      "version": "0.2.1",
+      "pak_name": "N64",
+      "rom_folder": "Roms/Nintendo 64 (N64)"
+    }
+  ],
+  "tool_paks": [
+    {
+      "name": "Collection Manager",
+      "repository": "https://github.com/jiserra/Collection-Manager.pak",
+      "version": "0.1.1",
+      "pak_name": "Collection Manager"
+    },
+    {
+      "name": "Developer",
+      "repository": "https://github.com/josegonzalez/minui-developer-pak",
+      "version": "0.5.0",
+      "pak_name": "Developer"
+    },
+    {
+      "name": "SSH Server",
+      "repository": "https://github.com/josegonzalez/minui-dropbear-server-pak",
+      "version": "0.5.0",
+      "pak_name": "SSH Server"
+    },
+    {
+      "name": "HTTP Server",
+      "repository": "https://github.com/josegonzalez/minui-dufs-server-pak",
+      "version": "0.5.5",
+      "pak_name": "HTTP Server"
+    },
+    {
+      "name": "FN Editor",
+      "repository": "https://github.com/josegonzalez/trimui-brick-fn-editor-pak",
+      "version": "0.3.4",
+      "pak_name": "FN Editor"
+    },
+    {
+      "name": "Moonlight",
+      "repository": "https://github.com/josegonzalez/trimui-brick-moonlight-pak",
+      "version": "0.3.3",
+      "pak_name": "Moonlight"
+    },
+    {
+      "name": "Random Game",
+      "repository": "https://github.com/josegonzalez/minui-random-game-pak",
+      "version": "0.3.1",
+      "pak_name": "Random Game"
+    },
+    {
+      "name": "Remote Terminal",
+      "repository": "https://github.com/josegonzalez/minui-remote-terminal-pak",
+      "version": "0.5.2",
+      "pak_name": "Remote Terminal"
+    },
+    {
+      "name": "Report",
+      "repository": "https://github.com/josegonzalez/minui-report-pak",
+      "version": "0.6.1",
+      "pak_name": "Report"
+    },
+    {
+      "name": "Screenshot Monitor",
+      "repository": "https://github.com/josegonzalez/minui-screenshot-monitor-pak",
+      "version": "0.5.0",
+      "pak_name": "Screenshot Monitor"
+    },
+    {
+      "name": "SFTPGo",
+      "repository": "https://github.com/josegonzalez/minui-sftpgo-server-pak",
+      "version": "0.3.1",
+      "pak_name": "FTP Server"
+    },
+    {
+      "name": "Syncthing",
+      "repository": "https://github.com/josegonzalez/minui-syncthing-pak",
+      "version": "0.3.0",
+      "pak_name": "Syncthing"
+    },
+    {
+      "name": "Terminal",
+      "repository": "https://github.com/josegonzalez/minui-terminal-pak",
+      "version": "0.6.2",
+      "pak_name": "Terminal"
+    },
+    {
+      "name": "USB Mass Storage",
+      "repository": "https://github.com/josegonzalez/trimui-brick-usb-mass-storage-pak",
+      "version": "0.3.1",
+      "pak_name": "USB Mass Storage"
+    },
+    {
+      "name": "WiFi",
+      "repository": "https://github.com/josegonzalez/minui-wifi-pak",
+      "version": "0.10.1",
+      "pak_name": "WiFi"
+    }
+  ]
+} 


### PR DESCRIPTION
By switching to a json file, we make it easier to automate version bumping as needed by #3.