### PR TITLE
feat: switch from sftpgo to ftpserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Below are the paks sourced by this pak collection. Please refer to the licenses 
 - [Dropbear SSH Server](https://github.com/josegonzalez/minui-dropbear-server-pak) by @josegonzalez
 - [Dufs HTTP Server](https://github.com/josegonzalez/minui-dufs-server-pak) by @josegonzalez
 - [Fn Editor](https://github.com/josegonzalez/trimui-brick-fn-editor-pak) by @josegonzalez
+- [FTP Server](https://github.com/josegonzalez/minui-ftpserver-pak) by @josegonzalez
 - [Moonlight](https://github.com/josegonzalez/trimui-brick-moonlight-pak) by @josegonzalez
 - [Random Game](https://github.com/josegonzalez/minui-random-game-pak) by @josegonzalez
 - [Remote Terminal](https://github.com/josegonzalez/minui-remote-terminal-pak) by @josegonzalez
 - [Report](https://github.com/josegonzalez/minui-report-pak) by @josegonzalez
 - [Screenshot Monitor](https://github.com/josegonzalez/minui-screenshot-monitor-pak) by @josegonzalez
-- [Sftpgo FTP Server](https://github.com/josegonzalez/minui-sftpgo-server-pak) by @josegonzalez
 - [Syncthing](https://github.com/josegonzalez/minui-syncthing-pak) by @josegonzalez
 - [Terminal](https://github.com/josegonzalez/minui-terminal-pak) by @josegonzalez
 - [Usb Mass Storage](https://github.com/josegonzalez/trimui-brick-usb-mass-storage-pak) by @josegonzalez

--- a/paks.json
+++ b/paks.json
@@ -77,9 +77,9 @@
       "pak_name": "Screenshot Monitor"
     },
     {
-      "name": "SFTPGo",
-      "repository": "https://github.com/josegonzalez/minui-sftpgo-server-pak",
-      "version": "0.4.0",
+      "name": "FTP Server",
+      "repository": "https://github.com/josegonzalez/minui-ftpserver-pak",
+      "version": "0.1.0",
       "pak_name": "FTP Server"
     },
     {


### PR DESCRIPTION
This reduces the need to worry about overlapping ports as now the FTP Server _only_ runs an FTP server.

Closes #2