### PR TITLE
feat: create separate pakman releases for minui and nextui

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,8 @@ jobs:
       - name: Compute release info
         id: release-info
         run: |
-          distribution="$({{ matrix.release }} | awk '{print $1}')"
-          allowed_platforms="$({{ matrix.release }} | awk '{print $2}')"
+          distribution="$(echo ${{ matrix.release }} | awk '{print $1}')"
+          allowed_platforms="$(echo ${{ matrix.release }} | awk '{print $2}')"
           new_zip_name="$(echo ${{ env.ZIP_TEMPLATE_NAME }} | sed 's/TEMPLATE/$distribution/')"
           echo "distribution=$distribution" >>"$GITHUB_OUTPUT"
           echo "allowed_platforms=$allowed_platforms" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         run: |
           distribution="$(echo ${{ matrix.release }} | awk '{print $1}')"
           allowed_platforms="$(echo ${{ matrix.release }} | awk '{print $2}')"
-          new_zip_name="$(echo ${{ env.ZIP_TEMPLATE_NAME }} | sed 's/TEMPLATE/$distribution/')"
+          new_zip_name="$(echo ${{ env.ZIP_TEMPLATE_NAME }} | sed "s/TEMPLATE/$distribution/")"
           echo "distribution=$distribution" >>"$GITHUB_OUTPUT"
           echo "allowed_platforms=$allowed_platforms" >>"$GITHUB_OUTPUT"
           echo "zip_name=$new_zip_name" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,17 @@ permissions:
 env:
   FOLDER_NAME: "Pakman"
   ZIP_NAME: "Pakman.zip"
+  ZIP_TEMPLATE_NAME: "Pakman-TEMPLATE.zip"
 
 jobs:
   build:
     name: build
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        release:
+          - "minui all"
+          - "nextui tg5040"
 
     steps:
       - name: Checkout
@@ -30,21 +36,52 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create package
-        run: make
+      - name: Compute release info
+        id: release-info
+        run: |
+          distribution="echo ${{ matrix.release }} | awk '{print $1}'"
+          allowed_platforms="echo ${{ matrix.release }} | awk '{print $2}'"
+          new_zip_name="$(echo ${{ env.ZIP_TEMPLATE_NAME }} | sed 's/TEMPLATE/$distribution/')"
+          echo "distribution=$distribution" >>"$GITHUB_OUTPUT"
+          echo "allowed_platforms=$allowed_platforms" >>"$GITHUB_OUTPUT"
+          echo "zip_name=$new_zip_name" >>"$GITHUB_OUTPUT"
+
+      - name: Create package for ${{ steps.release-info.outputs.distribution }} on ${{ steps.release-info.outputs.allowed_platforms }}
+        run: |
+          make DISTRIBUTION="${{ steps.release-info.outputs.distribution }}" ALLOWED_PLATFORMS="${{ steps.release-info.outputs.allowed_platforms }}" ZIP_NAME="${{ steps.release-info.outputs.zip_name }}"
 
       - name: Attest Build Provenance
         uses: actions/attest-build-provenance@v2.2.3
         with:
-          subject-path: "${{ env.ZIP_NAME }}"
+          subject-path: "${{ steps.release-info.outputs.zip_name }}"
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4.6.1
         with:
-          name: "${{ env.ZIP_NAME }}"
-          path: "${{ env.ZIP_NAME }}"
+          name: "${{ steps.release-info.outputs.zip_name }}"
+          path: "${{ steps.release-info.outputs.zip_name }}"
 
-      - name: Get Latest Tag
-        id: latest-tag
+  release:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Download MinUI Artifact
+        uses: actions/download-artifact@v4.2.1
+        with:
+          name: "Pakman-minui.zip"
+          path: "Pakman-minui.zip"
+
+      - name: Download NextUI Artifact
+        uses: actions/download-artifact@v4.2.1
+        with:
+          name: "Pakman-nextui.zip"
+          path: "Pakman-nextui.zip"
+
+      - name: List files
         run: |
-          echo GIT_LATEST_TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)")" >>"$GITHUB_OUTPUT"
+          ls -lah

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,8 @@ jobs:
       - name: Compute release info
         id: release-info
         run: |
-          distribution="echo ${{ matrix.release }} | awk '{print $1}'"
-          allowed_platforms="echo ${{ matrix.release }} | awk '{print $2}'"
+          distribution="$({{ matrix.release }} | awk '{print $1}')"
+          allowed_platforms="$({{ matrix.release }} | awk '{print $2}')"
           new_zip_name="$(echo ${{ env.ZIP_TEMPLATE_NAME }} | sed 's/TEMPLATE/$distribution/')"
           echo "distribution=$distribution" >>"$GITHUB_OUTPUT"
           echo "allowed_platforms=$allowed_platforms" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           distribution="$(echo ${{ matrix.release }} | awk '{print $1}')"
           allowed_platforms="$(echo ${{ matrix.release }} | awk '{print $2}')"
-          new_zip_name="$(echo ${{ env.ZIP_TEMPLATE_NAME }} | sed 's/TEMPLATE/$distribution/')"
+          new_zip_name="$(echo ${{ env.ZIP_TEMPLATE_NAME }} | sed "s/TEMPLATE/$distribution/")"
           echo "distribution=$distribution" >>"$GITHUB_OUTPUT"
           echo "allowed_platforms=$allowed_platforms" >>"$GITHUB_OUTPUT"
           echo "zip_name=$new_zip_name" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,11 +23,17 @@ permissions:
 env:
   FOLDER_NAME: "Pakman"
   ZIP_NAME: "Pakman.zip"
+  ZIP_TEMPLATE_NAME: "Pakman-TEMPLATE.zip"
 
 jobs:
   build:
     name: build
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        release:
+          - "minui all"
+          - "nextui tg5040"
 
     steps:
       - name: Checkout
@@ -35,19 +41,52 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create package
-        run: make
+      - name: Compute release info
+        id: release-info
+        run: |
+          distribution="$({{ matrix.release }} | awk '{print $1}')"
+          allowed_platforms="$({{ matrix.release }} | awk '{print $2}')"
+          new_zip_name="$(echo ${{ env.ZIP_TEMPLATE_NAME }} | sed 's/TEMPLATE/$distribution/')"
+          echo "distribution=$distribution" >>"$GITHUB_OUTPUT"
+          echo "allowed_platforms=$allowed_platforms" >>"$GITHUB_OUTPUT"
+          echo "zip_name=$new_zip_name" >>"$GITHUB_OUTPUT"
+
+      - name: Create package for ${{ steps.release-info.outputs.distribution }} on ${{ steps.release-info.outputs.allowed_platforms }}
+        id: create-package
+        run: |
+          make DISTRIBUTION="${{ steps.release-info.outputs.distribution }}" ALLOWED_PLATFORMS="${{ steps.release-info.outputs.allowed_platforms }}" ZIP_NAME="${{ steps.release-info.outputs.zip_name }}"
 
       - name: Attest Build Provenance
         uses: actions/attest-build-provenance@v2.2.3
         with:
-          subject-path: "${{ env.ZIP_NAME }}"
+          subject-path: "${{ steps.release-info.outputs.zip_name }}"
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4.6.1
         with:
-          name: "${{ env.ZIP_NAME }}"
-          path: "${{ env.ZIP_NAME }}"
+          name: "${{ steps.release-info.outputs.zip_name }}"
+          path: "${{ steps.release-info.outputs.zip_name }}"
+
+  release:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Download MinUI Artifact
+        uses: actions/download-artifact@v4.2.1
+        with:
+          name: "Pakman-minui.zip"
+          path: "Pakman-minui.zip"
+
+      - name: Download NextUI Artifact
+        uses: actions/download-artifact@v4.2.1
+        with:
+          name: "Pakman-nextui.zip"
+          path: "Pakman-nextui.zip"
 
       - name: Get Latest Tag
         id: latest-tag
@@ -77,7 +116,9 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2.2.1
         with:
-          files: "${{ env.ZIP_NAME }}"
+          files: |
+            Pakman-minui.zip
+            Pakman-nextui.zip
           generate_release_notes: true
           make_latest: "true"
           tag_name: ${{ steps.next-tag.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,8 +44,8 @@ jobs:
       - name: Compute release info
         id: release-info
         run: |
-          distribution="$({{ matrix.release }} | awk '{print $1}')"
-          allowed_platforms="$({{ matrix.release }} | awk '{print $2}')"
+          distribution="$(echo ${{ matrix.release }} | awk '{print $1}')"
+          allowed_platforms="$(echo ${{ matrix.release }} | awk '{print $2}')"
           new_zip_name="$(echo ${{ env.ZIP_TEMPLATE_NAME }} | sed 's/TEMPLATE/$distribution/')"
           echo "distribution=$distribution" >>"$GITHUB_OUTPUT"
           echo "allowed_platforms=$allowed_platforms" >>"$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ An automatically generated collection of paks for your MinUI installation
 > MinUI must have already been installed and booted at least once on your device. Please follow these steps after installing MinUI.
 
 1. Mount your MinUI SD card.
-2. Download the latest release from Github. It will be named `Pakman.zip`.
-3. Unzip the `Pakman.zip` file and browse to the new `Pakman` folder.
+2. Download the latest release from the [Github releases page](https://github.com/josegonzalez/pakman/releases). It will be named either `Pakman-minui.zip` or `Pakman-nextui.zip`.
+3. Unzip the `Pakman.zip` file and browse to the newly created `Pakman` folder.
 4. From within the `Pakman` folder, copy the `Emus`, `Roms`, and `Tools` directories onto your SD Card. When prompted, _merge_ the files into place.
 5. Confirm that your SD Card now has an `Emus/tg5040/N64.pak/launch.sh` file and a `Tools/tg5040/Developer.pak/launch.sh` file. If these do not exist, the paks were not installed properly. Please file an issue if so.
 6. Delete the `Pakman` folder and `Pakman.zip` file


### PR DESCRIPTION
Now that the two have diverged enough that there is somewhat of a separate ecosystem for certain NextUI-specific features, it makes sense to have two separate releases.

This also decreases the zip size for NextUI installs as it only targets the tg5040.