### PR TITLE
refactor: move wifi and fn editor to be minui-specific paks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Below are the paks sourced by this pak collection. Please refer to the licenses 
 - [Dropbear SSH Server](https://github.com/josegonzalez/minui-dropbear-server-pak) by @josegonzalez
 - [Dufs HTTP Server](https://github.com/josegonzalez/minui-dufs-server-pak) by @josegonzalez
 - [Favorites](https://github.com/ben16w/minui-favorites) by @ben16w
-- [Fn Editor](https://github.com/josegonzalez/trimui-brick-fn-editor-pak) by @josegonzalez
 - [FTP Server](https://github.com/josegonzalez/minui-ftpserver-pak) by @josegonzalez
 - [Gallery](https://github.com/josegonzalez/minui-gallery-pak) by @josegonzalez
 - [Media Player](https://github.com/josegonzalez/trimui-brick-media-player-pak) by @josegonzalez
@@ -60,6 +59,10 @@ Below are the paks sourced by this pak collection. Please refer to the licenses 
 - [Tailscale](https://github.com/ben16w/minui-tailscale) by @ben16w
 - [Terminal](https://github.com/josegonzalez/minui-terminal-pak) by @josegonzalez
 - [Usb Mass Storage](https://github.com/josegonzalez/trimui-brick-usb-mass-storage-pak) by @josegonzalez
-- [Wifi](https://github.com/josegonzalez/minui-wifi-pak) by @josegonzalez
+
+#### MinUI Only
+
+- [Fn Editor](https://github.com/josegonzalez/trimui-brick-fn-editor-pak) by @josegonzalez \[**minui**\]
+- [Wifi](https://github.com/josegonzalez/minui-wifi-pak) by @josegonzalez \[**minui**\]
 
 <!-- end tool paks -->

--- a/paks.json
+++ b/paks.json
@@ -83,7 +83,10 @@
       "name": "FN Editor",
       "repository": "https://github.com/josegonzalez/trimui-brick-fn-editor-pak",
       "version": "0.3.5",
-      "pak_name": "FN Editor"
+      "pak_name": "FN Editor",
+      "distributions": [
+        "minui"
+      ]
     },
     {
       "name": "FTP Server",
@@ -167,7 +170,10 @@
       "name": "Wifi",
       "repository": "https://github.com/josegonzalez/minui-wifi-pak",
       "version": "0.14.10",
-      "pak_name": "Wifi"
+      "pak_name": "Wifi",
+      "distributions": [
+        "minui"
+      ]
     }
   ]
 }


### PR DESCRIPTION
NextUI has wifi built-in and has function key mapping so the latter doesn't need to be there.