### PR TITLE
Add RGB Settings tool pak.

### DIFF
--- a/paks.json
+++ b/paks.json
@@ -159,6 +159,12 @@
       "pak_name": "Report"
     },
     {
+      "name": "RGB Settings",
+      "repository": "https://github.com/fchavonet/bash-minui-rg40xxv-rgb_settings_tool",
+      "version": "v2.0.0",
+      "pak_name": "RGB Settings"
+    },
+    {
       "name": "Screenshot Monitor",
       "repository": "https://github.com/josegonzalez/minui-screenshot-monitor-pak",
       "version": "0.9.0",


### PR DESCRIPTION
## Summary

Adds the RG40XXV RGB Settings tool `.pak` to Pakman.

This tool allows users to control the analog stick RGB LED on the Anbernic RG40XXV while running MinUI.

## Details

- Single `.pak` structure.
- Includes `pak.json`.
- Uses `minui-list`.
- Compatible with MinUI.
- Designed for the Anbernic RG40XXV.
- Release version: v2.0.0.